### PR TITLE
docs: add concrete BYO key setup recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,23 @@ If both keys are set, Krust uses **TinyFish first**, then falls back to **Brave*
 
 > Note: if your MCP client does not expand `${VAR}` placeholders, use a launcher script that exports keys from your local secret store before exec'ing `krust-mcp`.
 
+#### One-shot setup scripts (included in this repo)
+
+From repo root, run one of:
+
+```bash
+# macOS Keychain
+./scripts/setup/macos-keychain.sh
+
+# 1Password CLI (macOS/Linux)
+./scripts/setup/onepassword.sh
+
+# Linux secret stores (pass or secret-tool)
+./scripts/setup/linux-secrets.sh
+```
+
+Each script creates a launcher (default: `~/bin/krust-mcp-launch` on macOS/1Password, `~/.local/bin/krust-mcp-launch` on Linux). Point MCP `command` to that launcher.
+
 #### macOS + Keychain (recommended)
 
 1) Store keys in Keychain (choose one method):

--- a/scripts/setup/linux-secrets.sh
+++ b/scripts/setup/linux-secrets.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "This setup script is for Linux secret stores." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+DEFAULT_BINARY="$REPO_ROOT/target/release/krust-mcp"
+BINARY_PATH="${KRUST_MCP_BINARY:-$DEFAULT_BINARY}"
+LAUNCHER_PATH="${KRUST_LAUNCHER_PATH:-$HOME/.local/bin/krust-mcp-launch}"
+
+echo "== Krust Linux secret setup =="
+read -r -p "Path to krust-mcp binary [$BINARY_PATH]: " input_binary
+if [[ -n "${input_binary}" ]]; then
+  BINARY_PATH="$input_binary"
+fi
+
+echo
+echo "Choose backend:"
+echo "  1) pass"
+echo "  2) secret-tool (libsecret)"
+read -r -p "Selection [1/2]: " sel
+
+mkdir -p "$(dirname "$LAUNCHER_PATH")"
+
+if [[ "$sel" == "1" ]]; then
+  if ! command -v pass >/dev/null 2>&1; then
+    echo "'pass' not found. Install it first." >&2
+    exit 1
+  fi
+
+  tiny_entry="${KRUST_TINYFISH_PASS_ENTRY:-krust/tinyfish_api_key}"
+  brave_entry="${KRUST_BRAVE_PASS_ENTRY:-krust/brave_api_key}"
+
+  echo
+  read -r -p "Store TinyFish key now in pass entry '$tiny_entry'? [y/N]: " store_tiny
+  if [[ "${store_tiny,,}" == "y" ]]; then
+    pass insert "$tiny_entry"
+  fi
+
+  read -r -p "Store Brave key now in pass entry '$brave_entry'? [y/N]: " store_brave
+  if [[ "${store_brave,,}" == "y" ]]; then
+    pass insert "$brave_entry"
+  fi
+
+  cat > "$LAUNCHER_PATH" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v pass >/dev/null 2>&1; then
+  if TINY_VALUE=\$(pass show '$tiny_entry' 2>/dev/null | head -n1); then
+    export TINYFISH_API_KEY="\$TINY_VALUE"
+  fi
+  if BRAVE_VALUE=\$(pass show '$brave_entry' 2>/dev/null | head -n1); then
+    export BRAVE_API_KEY="\$BRAVE_VALUE"
+  fi
+fi
+
+exec "$BINARY_PATH" "\$@"
+EOF
+
+elif [[ "$sel" == "2" ]]; then
+  if ! command -v secret-tool >/dev/null 2>&1; then
+    echo "'secret-tool' not found. Install libsecret-tools first." >&2
+    exit 1
+  fi
+
+  tiny_account="${KRUST_TINYFISH_SECRET_ACCOUNT:-tinyfish_api_key}"
+  brave_account="${KRUST_BRAVE_SECRET_ACCOUNT:-brave_api_key}"
+
+  echo
+  read -r -p "Store TinyFish key now with secret-tool account '$tiny_account'? [y/N]: " store_tiny
+  if [[ "${store_tiny,,}" == "y" ]]; then
+    secret-tool store --label='Krust TinyFish API Key' service krust account "$tiny_account"
+  fi
+
+  read -r -p "Store Brave key now with secret-tool account '$brave_account'? [y/N]: " store_brave
+  if [[ "${store_brave,,}" == "y" ]]; then
+    secret-tool store --label='Krust Brave API Key' service krust account "$brave_account"
+  fi
+
+  cat > "$LAUNCHER_PATH" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v secret-tool >/dev/null 2>&1; then
+  if TINY_VALUE=\$(secret-tool lookup service krust account '$tiny_account' 2>/dev/null); then
+    export TINYFISH_API_KEY="\$TINY_VALUE"
+  fi
+  if BRAVE_VALUE=\$(secret-tool lookup service krust account '$brave_account' 2>/dev/null); then
+    export BRAVE_API_KEY="\$BRAVE_VALUE"
+  fi
+fi
+
+exec "$BINARY_PATH" "\$@"
+EOF
+
+else
+  echo "Invalid selection. Use 1 or 2." >&2
+  exit 1
+fi
+
+chmod 700 "$LAUNCHER_PATH"
+
+echo
+echo "Done. Launcher created at: $LAUNCHER_PATH"
+echo "Set your MCP command to: $LAUNCHER_PATH"

--- a/scripts/setup/macos-keychain.sh
+++ b/scripts/setup/macos-keychain.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This setup script is for macOS (Keychain) only." >&2
+  exit 1
+fi
+
+if ! command -v security >/dev/null 2>&1; then
+  echo "Missing 'security' CLI. It should be available on macOS." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+DEFAULT_BINARY="$REPO_ROOT/target/release/krust-mcp"
+BINARY_PATH="${KRUST_MCP_BINARY:-$DEFAULT_BINARY}"
+LAUNCHER_PATH="${KRUST_LAUNCHER_PATH:-$HOME/bin/krust-mcp-launch}"
+TINY_SERVICE="${KRUST_TINYFISH_SERVICE:-krust_tinyfish_api_key}"
+BRAVE_SERVICE="${KRUST_BRAVE_SERVICE:-krust_brave_api_key}"
+
+echo "== Krust macOS Keychain setup =="
+echo
+read -r -p "Path to krust-mcp binary [$BINARY_PATH]: " input_binary
+if [[ -n "${input_binary}" ]]; then
+  BINARY_PATH="$input_binary"
+fi
+
+if [[ ! -x "$BINARY_PATH" ]]; then
+  echo "Warning: binary not executable at: $BINARY_PATH" >&2
+  echo "Build it first with: cargo build --release --bin krust-mcp" >&2
+fi
+
+echo
+echo "Enter API keys (leave blank to skip either provider)."
+read -r -s -p "TinyFish API key: " tiny_key
+echo
+read -r -s -p "Brave API key: " brave_key
+echo
+
+if [[ -n "$tiny_key" ]]; then
+  security add-generic-password -U -a "$USER" -s "$TINY_SERVICE" -w "$tiny_key"
+  echo "Stored TinyFish key in Keychain service: $TINY_SERVICE"
+else
+  echo "Skipped TinyFish key storage."
+fi
+
+if [[ -n "$brave_key" ]]; then
+  security add-generic-password -U -a "$USER" -s "$BRAVE_SERVICE" -w "$brave_key"
+  echo "Stored Brave key in Keychain service: $BRAVE_SERVICE"
+else
+  echo "Skipped Brave key storage."
+fi
+
+unset tiny_key brave_key
+
+mkdir -p "$(dirname "$LAUNCHER_PATH")"
+cat > "$LAUNCHER_PATH" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if TINY_VALUE=\$(security find-generic-password -a "\$USER" -s "$TINY_SERVICE" -w 2>/dev/null); then
+  export TINYFISH_API_KEY="\$TINY_VALUE"
+fi
+
+if BRAVE_VALUE=\$(security find-generic-password -a "\$USER" -s "$BRAVE_SERVICE" -w 2>/dev/null); then
+  export BRAVE_API_KEY="\$BRAVE_VALUE"
+fi
+
+exec "$BINARY_PATH" "\$@"
+EOF
+chmod 700 "$LAUNCHER_PATH"
+
+echo
+echo "Done. Launcher created at: $LAUNCHER_PATH"
+echo "Set your MCP command to: $LAUNCHER_PATH"

--- a/scripts/setup/onepassword.sh
+++ b/scripts/setup/onepassword.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v op >/dev/null 2>&1; then
+  echo "1Password CLI (op) not found. Install it first: https://developer.1password.com/docs/cli/get-started/" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+DEFAULT_BINARY="$REPO_ROOT/target/release/krust-mcp"
+BINARY_PATH="${KRUST_MCP_BINARY:-$DEFAULT_BINARY}"
+LAUNCHER_PATH="${KRUST_LAUNCHER_PATH:-$HOME/bin/krust-mcp-launch}"
+DEFAULT_TINY_REF="op://Private/Krust API Keys/tinyfish"
+DEFAULT_BRAVE_REF="op://Private/Krust API Keys/brave"
+
+echo "== Krust 1Password setup =="
+read -r -p "Path to krust-mcp binary [$BINARY_PATH]: " input_binary
+if [[ -n "${input_binary}" ]]; then
+  BINARY_PATH="$input_binary"
+fi
+
+read -r -p "TinyFish secret reference [$DEFAULT_TINY_REF]: " tiny_ref
+read -r -p "Brave secret reference [$DEFAULT_BRAVE_REF]: " brave_ref
+tiny_ref="${tiny_ref:-$DEFAULT_TINY_REF}"
+brave_ref="${brave_ref:-$DEFAULT_BRAVE_REF}"
+
+echo
+echo "Checking 1Password access..."
+if ! op read "$tiny_ref" >/dev/null 2>&1; then
+  echo "Warning: could not read TinyFish reference now: $tiny_ref" >&2
+  echo "Make sure 'op signin' is active and the reference exists." >&2
+fi
+if ! op read "$brave_ref" >/dev/null 2>&1; then
+  echo "Warning: could not read Brave reference now: $brave_ref" >&2
+  echo "Make sure 'op signin' is active and the reference exists." >&2
+fi
+
+mkdir -p "$(dirname "$LAUNCHER_PATH")"
+cat > "$LAUNCHER_PATH" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v op >/dev/null 2>&1; then
+  if TINY_VALUE=\$(op read '$tiny_ref' 2>/dev/null); then
+    export TINYFISH_API_KEY="\$TINY_VALUE"
+  fi
+  if BRAVE_VALUE=\$(op read '$brave_ref' 2>/dev/null); then
+    export BRAVE_API_KEY="\$BRAVE_VALUE"
+  fi
+fi
+
+exec "$BINARY_PATH" "\$@"
+EOF
+chmod 700 "$LAUNCHER_PATH"
+
+echo
+echo "Done. Launcher created at: $LAUNCHER_PATH"
+echo "Set your MCP command to: $LAUNCHER_PATH"


### PR DESCRIPTION
## Summary
Adds practical, user-friendly setup recipes for BYO search keys.

## What this adds
- macOS Keychain setup (store + launcher script + chmod + MCP command usage)
- 1Password CLI launcher script option (`op read`)
- Linux options (`pass`, `secret-tool`) with guidance to use launcher scripts

## Why
The previous README section explained the BYO model but did not give concrete copy/paste setup paths for common local secret stores.
