### PR TITLE
docs(setup): clarify default path prompt behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ From repo root:
 
 What these scripts do:
 1. Prompt for required inputs/secrets.
+   - For the first prompt (`Path to krust-mcp binary`), press **Enter** to accept the default shown in brackets.
 2. Create a launcher script (`krust-mcp-launch`) that fetches keys from your secret store.
 3. Tell you the launcher path to use in MCP config.
 

--- a/scripts/setup/linux-secrets.sh
+++ b/scripts/setup/linux-secrets.sh
@@ -14,10 +14,12 @@ BINARY_PATH="${KRUST_MCP_BINARY:-$DEFAULT_BINARY}"
 LAUNCHER_PATH="${KRUST_LAUNCHER_PATH:-$HOME/.local/bin/krust-mcp-launch}"
 
 echo "== Krust Linux secret setup =="
-read -r -p "Path to krust-mcp binary [$BINARY_PATH]: " input_binary
+read -r -p "Path to krust-mcp binary [default: $BINARY_PATH] (press Enter to accept): " input_binary
 if [[ -n "${input_binary}" ]]; then
   BINARY_PATH="$input_binary"
 fi
+
+echo "Using krust-mcp binary: $BINARY_PATH"
 
 echo
 echo "Choose backend:"

--- a/scripts/setup/macos-keychain.sh
+++ b/scripts/setup/macos-keychain.sh
@@ -22,10 +22,12 @@ BRAVE_SERVICE="${KRUST_BRAVE_SERVICE:-krust_brave_api_key}"
 
 echo "== Krust macOS Keychain setup =="
 echo
-read -r -p "Path to krust-mcp binary [$BINARY_PATH]: " input_binary
+read -r -p "Path to krust-mcp binary [default: $BINARY_PATH] (press Enter to accept): " input_binary
 if [[ -n "${input_binary}" ]]; then
   BINARY_PATH="$input_binary"
 fi
+
+echo "Using krust-mcp binary: $BINARY_PATH"
 
 if [[ ! -x "$BINARY_PATH" ]]; then
   echo "Warning: binary not executable at: $BINARY_PATH" >&2

--- a/scripts/setup/onepassword.sh
+++ b/scripts/setup/onepassword.sh
@@ -16,10 +16,12 @@ DEFAULT_TINY_REF="op://Private/Krust API Keys/tinyfish"
 DEFAULT_BRAVE_REF="op://Private/Krust API Keys/brave"
 
 echo "== Krust 1Password setup =="
-read -r -p "Path to krust-mcp binary [$BINARY_PATH]: " input_binary
+read -r -p "Path to krust-mcp binary [default: $BINARY_PATH] (press Enter to accept): " input_binary
 if [[ -n "${input_binary}" ]]; then
   BINARY_PATH="$input_binary"
 fi
+
+echo "Using krust-mcp binary: $BINARY_PATH"
 
 read -r -p "TinyFish secret reference [$DEFAULT_TINY_REF]: " tiny_ref
 read -r -p "Brave secret reference [$DEFAULT_BRAVE_REF]: " brave_ref


### PR DESCRIPTION
## Summary
Small UX clarification for setup scripts and README.

## Changes
- Updated all setup scripts to make the first prompt explicit:
  - `Path to krust-mcp binary [default: ...] (press Enter to accept)`
- Scripts now print the resolved binary path after prompt.
- README Path A section now explicitly says pressing Enter accepts the default binary path.

## Why
Users found the first prompt ambiguous about whether a default is applied when left blank.
